### PR TITLE
Add preloaded settings registry; de-hardcode interaction values

### DIFF
--- a/AI_Implementation_Plan/Settings_Preload_Design.md
+++ b/AI_Implementation_Plan/Settings_Preload_Design.md
@@ -1,0 +1,62 @@
+# Settings Preload Provider — Design Note
+
+Goal: make `BotSetting` the single source of truth that the UI edits and the
+bot consumes, **preloaded once at startup** before any interaction logic runs,
+so commands stop hardcoding Discord IDs / env values.
+
+The round-trip we want:
+
+```
+BotSettings.svelte  →  Api  →  DB (BotSetting)  →  preloaded cache  →  interactions
+        ▲                                                                     │
+        └─────────────────────────  reads back  ◄────────────────────────────┘
+```
+
+## What already exists (don't rebuild)
+
+- `Domain/database/BotSetting.cs` — entity (BotId, OpenAIModel, OpenAIPrompt,
+  Token, AdminRoleIds, EvilId, LogChannelId, EvilLogChannelId)
+- `Infrastructure/.../BotSettingRepository.cs` + `BotSettingsSeeder.cs` — load/seed
+- `Frontend/.../routes/BotSettings.svelte` + `types/database.ts` — UI form bound
+  to those exact fields
+- `Application/ConfigurationReader.cs` — startup config load
+
+## What's missing / to build
+
+1. **Extend the settings model** to cover values currently hardcoded in handlers.
+   Today `BotSetting` has 3 channel IDs; interactions reference more:
+   - verified / unverified role IDs (`VerifyUserAgeCommand.cs:34-36`)
+   - log channel (`VerifyUserAgeCommand.cs:36`)
+   - contact category ID (`ContactUserCommand.cs:45`)
+   - giveaway scoreboard channel (`GiveawayCommand.cs:21`)
+   - Airy listen channels — 5 IDs (`TalkToAiry.cs:26`)
+   - rules channel (`VerifyFrontend.cs:12`)
+   - owner/admin user id `405431299323461634` (`GiveawayCommand.cs:161,183`)
+   - AI defaults: model, max_tokens, retries (`OpenAIClient.cs`, `OllamaClient.cs`)
+
+   Note: many of these are per-guild. Consider a `GuildConfiguration` table
+   keyed by guild id rather than overloading `BotSetting`.
+
+2. **A preloaded settings provider** — singleton, populated at startup (after
+   seeding, before bots start handling events). Holds the resolved values in
+   memory; exposes typed accessors. One refresh path so a UI save can invalidate.
+
+3. **Swap literals for lookups** — replace hardcoded `ulong` literals in the
+   handlers above with provider accessors.
+
+4. **Standardize loading** — remove the lazy `Environment.GetEnvironmentVariable
+   ("ADMINROLEID")` in `UserService.cs:46`; route it through the provider.
+
+## Sync risk to address
+
+Frontend field metadata is hand-maintained in `schema.ts` + `database.ts` and
+must stay aligned with the C# `BotSetting`. No shared source today — they can
+drift. Out of scope for first pass, but worth a follow-up.
+
+## Order of work
+
+1. Decide model shape (extend `BotSetting` vs new `GuildConfiguration`).
+2. Build the preload provider + DI registration + startup hook.
+3. Migrate handlers one at a time off literals.
+4. Wire the Api endpoint so the Svelte page actually persists (ties into the
+   Api/Frontend gap from the main review).

--- a/AiryBotCode.Application/Comands/ConversationalInteractions/TalkToAiry.cs
+++ b/AiryBotCode.Application/Comands/ConversationalInteractions/TalkToAiry.cs
@@ -2,6 +2,7 @@
 using AiryBotCode.Application.Interfaces;
 using AiryBotCode.Application.Interfaces.Service;
 using AiryBotCode.Application.Services.AIService;
+using AiryBotCode.Application.Settings;
 using AiryBotCode.Domain.database;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,21 +12,25 @@ namespace AiryBotCode.Application.Comands.ConversationalInteractions
     {
         private readonly IConversationManagerService _conversationManagerService;
         private readonly IConfigurationReader _config;
+        private readonly ISettingsProvider _settings;
         private readonly OpenAIClient _openAIClient;
         private static readonly SemaphoreSlim _messageSavingSemaphore = new SemaphoreSlim(1, 1);
 
         public TalkToAiry(IServiceProvider serviceProvider) : base(serviceProvider)
         {
             _config = serviceProvider.GetRequiredService<IConfigurationReader>();
-            _openAIClient = new OpenAIClient(_config.GetOpenAIApiKey());
+            _settings = serviceProvider.GetRequiredService<ISettingsProvider>();
+            _openAIClient = new OpenAIClient(
+                _config.GetOpenAIApiKey(),
+                _settings.Current.Ai.Model,
+                _settings.Current.Ai.MaxTokens);
             _conversationManagerService = serviceProvider.GetRequiredService<IConversationManagerService>();
         }
 
         public async Task ProcessMessageAsync(SocketMessage message)
         {
-            List<ulong> channelsId = new List<ulong> { 1182267222152982533, 1182267222152982535, 1182267222152982534, 1182267779135590490, 1236609199144697938 };
             if (!message.Content.Contains($"<@{_config.GetBotId()}>")) return;
-            if (!channelsId.Contains(message.Channel.Id)) return; // Ignore bot spam channel
+            if (!_settings.Current.Channels.Listen.Contains(message.Channel.Id)) return; // Only respond in configured channels
 
             var guildChannel = message.Channel as SocketGuildChannel;
             string displayName = (message.Author as SocketGuildUser)?.DisplayName ?? message.Author.Username;

--- a/AiryBotCode.Application/Comands/SlashCommands/GiveawayCommand.cs
+++ b/AiryBotCode.Application/Comands/SlashCommands/GiveawayCommand.cs
@@ -2,6 +2,7 @@ using AiryBotCode.Application.Services;
 using AiryBotCode.Domain.database;
 using AiryBotCode.Application.Frontend;
 using AiryBotCode.Application.Services.Database.GiveAway;
+using AiryBotCode.Application.Settings;
 using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,9 +17,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
     public class GiveawayCommand : EvilCommand
     {
         private readonly GiveAwayUserService _giveAwayUserService;
-
-        // Replace with your actual channel ID
-        private const ulong ScoreboardChannelId = 1182267222152982535; // IMPORTANT: REPLACE THIS
+        private readonly ISettingsProvider _settings;
 
         private static readonly Dictionary<ulong, ulong> ScoreboardMessageIds = new Dictionary<ulong, ulong>();
         private static readonly Dictionary<ulong, (ulong messageId, ulong channelId)> GiveawayMessageIds = new Dictionary<ulong, (ulong, ulong)>();
@@ -34,6 +33,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
         {
             Name = "start-event";
             _giveAwayUserService = serviceProvider.GetRequiredService<GiveAwayUserService>();
+            _settings = serviceProvider.GetRequiredService<ISettingsProvider>();
         }
 
         public override SlashCommandBuilder GetCommand()
@@ -46,7 +46,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
         public async Task HandleStartEventCommand(SocketSlashCommand command)
         {
             var guildId = command.GuildId.Value;
-            var scoreboardChannel = _client.GetChannel(ScoreboardChannelId) as SocketTextChannel;
+            var scoreboardChannel = _client.GetChannel(_settings.Current.Channels.GiveawayScoreboard) as SocketTextChannel;
             if (scoreboardChannel == null)
             {
                 await command.RespondAsync("Error: Scoreboard channel not found. Please configure the bot.", ephemeral: true);
@@ -158,7 +158,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
 
         private async Task HandleClearUsersButton(SocketMessageComponent component)
         {
-            if (component.User.Id != 405431299323461634)
+            if (component.User.Id != _settings.Current.Owner)
             {
                 await component.RespondAsync("You do not have permission to use this button.", ephemeral: true);
                 return;
@@ -180,7 +180,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
 
         private async Task HandleConfirmClearUsersButton(SocketMessageComponent component)
         {
-            if (component.User.Id != 405431299323461634)
+            if (component.User.Id != _settings.Current.Owner)
             {
                 await component.RespondAsync("You do not have permission to use this button.", ephemeral: true);
                 return;
@@ -191,7 +191,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
             var guildId = component.GuildId.Value;
             if (ScoreboardMessageIds.TryGetValue(guildId, out var scoreboardMessageId))
             {
-                var scoreboardChannel = _client.GetChannel(ScoreboardChannelId) as SocketTextChannel;
+                var scoreboardChannel = _client.GetChannel(_settings.Current.Channels.GiveawayScoreboard) as SocketTextChannel;
                 var scoreboardMessage = await scoreboardChannel.GetMessageAsync(scoreboardMessageId) as IUserMessage;
                 if (scoreboardMessage != null)
                 {
@@ -247,7 +247,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
             }
             if (ScoreboardMessageIds.TryGetValue(guildId, out var scoreboardMessageId))
             {
-                var scoreboardChannel = _client.GetChannel(ScoreboardChannelId) as SocketTextChannel;
+                var scoreboardChannel = _client.GetChannel(_settings.Current.Channels.GiveawayScoreboard) as SocketTextChannel;
                 var scoreboardMessage = await scoreboardChannel.GetMessageAsync(scoreboardMessageId) as IUserMessage;
                 if (scoreboardMessage != null)
                 {
@@ -309,7 +309,7 @@ namespace AiryBotCode.Application.Comands.SlashCommands
 
             // Update scoreboard
             var allUsers = await _giveAwayUserService.GetAllUsers();
-            var scoreboardChannel = _client.GetChannel(ScoreboardChannelId) as SocketTextChannel;
+            var scoreboardChannel = _client.GetChannel(_settings.Current.Channels.GiveawayScoreboard) as SocketTextChannel;
             if (scoreboardChannel != null && ScoreboardMessageIds.TryGetValue(guildId, out var messageId))
             {
                 var scoreboardMessage = await scoreboardChannel.GetMessageAsync(messageId) as IUserMessage;

--- a/AiryBotCode.Application/Comands/SlashCommands/VerifyUserAgeCommand.cs
+++ b/AiryBotCode.Application/Comands/SlashCommands/VerifyUserAgeCommand.cs
@@ -1,6 +1,7 @@
 ﻿using AiryBotCode.Application.Frontend;
 using AiryBotCode.Application.Services.Loging;
 using AiryBotCode.Application.Services.User;
+using AiryBotCode.Application.Settings;
 using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,11 +13,13 @@ namespace AiryBotCode.Application.Comands.SlashCommands
     {
         public const string ActionEdit = "edit";
         protected UserService _userService;
+        private readonly ISettingsProvider _settings;
 
         public VerifyUserAgeCommand(IServiceProvider serviceProvider) : base(serviceProvider)
         {
             Name = "verif";
             _userService = serviceProvider.GetRequiredService<UserService>();
+            _settings = serviceProvider.GetRequiredService<ISettingsProvider>();
         }
 
         public override SlashCommandBuilder GetCommand()
@@ -31,9 +34,9 @@ namespace AiryBotCode.Application.Comands.SlashCommands
         {
             try
             {
-                ulong verifiedRoleId = 1283099014476075151;
-                ulong unverifiedRoleId = 1283101142255144991;
-                ulong logChannelId = 1283102267129724958;
+                ulong verifiedRoleId = _settings.Current.Roles.Verified;
+                ulong unverifiedRoleId = _settings.Current.Roles.Unverified;
+                ulong logChannelId = _settings.Current.Channels.VerifyLog;
 
                 // The staff/admin who ran the command
                 var executedBy = command.User as SocketGuildUser;

--- a/AiryBotCode.Application/ConfigurationReader.cs
+++ b/AiryBotCode.Application/ConfigurationReader.cs
@@ -27,7 +27,34 @@ namespace AiryBotCode.Application.Interfaces
                 EvilId = GetEvilId(),
                 EvilLogChannelId = GetEvilLogChannelId(),
                 LogChannelId = GetLogChannelId(),
+
+                // Optional values that back the AirySettings registry. These are
+                // default-safe so existing configs keep working until filled in.
+                OwnerId = ReadOptionalUlong("Bots:OwnerId"),
+                ListenChannelIds = ReadOptionalCsvIds("Bots:ListenChannelIds"),
+                VerifiedRoleId = ReadOptionalUlong("Bots:VerifiedRoleId"),
+                UnverifiedRoleId = ReadOptionalUlong("Bots:UnverifiedRoleId"),
+                VerifyLogChannelId = ReadOptionalUlong("Bots:VerifyLogChannelId"),
+                RulesChannelId = ReadOptionalUlong("Bots:RulesChannelId"),
+                GiveawayScoreboardChannelId = ReadOptionalUlong("Bots:GiveawayScoreboardChannelId"),
+                ContactCategoryId = ReadOptionalUlong("Bots:ContactCategoryId"),
+                MaxTokens = ReadOptionalInt("OpenAI:MaxTokens", 1000),
+                RetryAttempts = ReadOptionalInt("OpenAI:RetryAttempts", 2),
             };
+        }
+
+        // --- Tolerant readers for optional, default-safe settings ---
+
+        private ulong ReadOptionalUlong(string key)
+            => ulong.TryParse(_configuration[key], out var value) ? value : 0UL;
+
+        private int ReadOptionalInt(string key, int fallback)
+            => int.TryParse(_configuration[key], out var value) ? value : fallback;
+
+        private string ReadOptionalCsvIds(string key)
+        {
+            var list = _configuration.GetSection(key).Get<List<string>>();
+            return (list == null || !list.Any()) ? string.Empty : string.Join(",", list);
         }
         public string GetBotToken()
         {

--- a/AiryBotCode.Application/RegisterApplication.cs
+++ b/AiryBotCode.Application/RegisterApplication.cs
@@ -10,6 +10,7 @@ using AiryBotCode.Application.Interfaces.Service;
 using AiryBotCode.Application.Services.AIService;
 using AiryBotCode.Application.Services.Database.ChatHistory;
 using AiryBotCode.Application.Services.Database.GiveAway;
+using AiryBotCode.Application.Settings;
 
 namespace AiryBotCode.Application
 {
@@ -19,6 +20,8 @@ namespace AiryBotCode.Application
         {
             // Configuration and AI Clients
             services.AddSingleton<IConfigurationReader, ConfigurationReader>();
+            // Preloaded, UI-reflectable settings registry (single source of truth)
+            services.AddSingleton<ISettingsProvider, SettingsProvider>();
             services.AddSingleton(provider =>
             {
                 var configReader = provider.GetRequiredService<IConfigurationReader>();

--- a/AiryBotCode.Application/Services/AIService/OpenAIClient.cs
+++ b/AiryBotCode.Application/Services/AIService/OpenAIClient.cs
@@ -12,12 +12,15 @@ namespace AiryBotCode.Application.Services.AIService
         private readonly HttpClient _httpClient;
         private readonly string _modelName;
         private readonly string _apiKey;
+        private readonly int _maxTokens;
 
         public OpenAIClient(string apiKey,
-            string modelName = "gpt-4.1-mini")
+            string modelName = "gpt-4.1-mini",
+            int maxTokens = 1000)
         {
             _modelName = modelName;
             _apiKey = apiKey;
+            _maxTokens = maxTokens;
             _httpClient = new HttpClient
             {
                 BaseAddress = new Uri("https://api.openai.com/v1/")
@@ -48,7 +51,7 @@ namespace AiryBotCode.Application.Services.AIService
             {
                 model = _modelName,
                 messages = openAIMessages, // Send the structured messages
-                max_tokens = 1000
+                max_tokens = _maxTokens
             };
 
             HttpResponseMessage response;

--- a/AiryBotCode.Application/Services/User/UserService.cs
+++ b/AiryBotCode.Application/Services/User/UserService.cs
@@ -1,10 +1,18 @@
-﻿using Discord;
+﻿using AiryBotCode.Application.Settings;
+using Discord;
 using Discord.WebSocket;
 
 namespace AiryBotCode.Application.Services.User
 {
     public class UserService
     {
+        private readonly ISettingsProvider _settings;
+
+        public UserService(ISettingsProvider settings)
+        {
+            _settings = settings;
+        }
+
         public async Task<int> ClearMessage(int timeInMinutes, SocketGuildUser user)
         {
             if (user == null || user.Guild == null)
@@ -43,10 +51,10 @@ namespace AiryBotCode.Application.Services.User
 
         public async Task<ulong> GetAdminRole(SocketInteraction command)
         {
-            var adminRoleId = ulong.TryParse(Environment.GetEnvironmentVariable("ADMINROLEID"), out var roleId) ? roleId : 0;
+            var adminRoleId = _settings.Current.Roles.Admin.FirstOrDefault();
             if (adminRoleId == 0)
             {
-                await command.RespondAsync("Admin role ID not found in environment variables. CONTACT evil", ephemeral: true);
+                await command.RespondAsync("Admin role ID is not configured. CONTACT evil", ephemeral: true);
                 return 0;
             }
             return adminRoleId;

--- a/AiryBotCode.Application/Settings/AirySettings.cs
+++ b/AiryBotCode.Application/Settings/AirySettings.cs
@@ -1,0 +1,108 @@
+using AiryBotCode.Domain.database;
+
+namespace AiryBotCode.Application.Settings
+{
+    /// <summary>
+    /// Strongly-typed, grouped view of every configurable value the bot uses at
+    /// runtime. This is the single, discoverable place handlers read settings
+    /// from — no more hardcoded Discord IDs scattered through interaction logic.
+    ///
+    /// Values are defined once here and shared across handlers (e.g. many places
+    /// read the same <c>Channels.Log</c> or <c>Owner</c>), and the grouping makes
+    /// the relationships between them explicit. Built from the persisted
+    /// <see cref="BotSetting"/> via <see cref="FromBotSetting"/> and preloaded at
+    /// startup by <see cref="ISettingsProvider"/>.
+    /// </summary>
+    public sealed class AirySettings
+    {
+        /// <summary>Bot owner / super-admin user id. Shared by every owner-only check.</summary>
+        public ulong Owner { get; init; }
+
+        public ChannelSettings Channels { get; init; } = new();
+        public RoleSettings Roles { get; init; } = new();
+        public CategorySettings Categories { get; init; } = new();
+        public AiSettings Ai { get; init; } = new();
+
+        /// <summary>Project the flat persisted setting into the grouped tree.</summary>
+        public static AirySettings FromBotSetting(BotSetting s) => new()
+        {
+            Owner = s.OwnerId,
+            Channels = new ChannelSettings
+            {
+                Log = s.LogChannelId,
+                EvilLog = s.EvilLogChannelId,
+                VerifyLog = s.VerifyLogChannelId,
+                Rules = s.RulesChannelId,
+                GiveawayScoreboard = s.GiveawayScoreboardChannelId,
+                Listen = ParseIds(s.ListenChannelIds),
+            },
+            Roles = new RoleSettings
+            {
+                Verified = s.VerifiedRoleId,
+                Unverified = s.UnverifiedRoleId,
+                Admin = ParseIds(s.AdminRoleIds),
+            },
+            Categories = new CategorySettings
+            {
+                Contact = s.ContactCategoryId,
+            },
+            Ai = new AiSettings
+            {
+                Model = string.IsNullOrWhiteSpace(s.OpenAIModel) ? "gpt-4.1-mini" : s.OpenAIModel,
+                Prompt = s.OpenAIPrompt ?? string.Empty,
+                MaxTokens = s.MaxTokens > 0 ? s.MaxTokens : 1000,
+                RetryAttempts = s.RetryAttempts > 0 ? s.RetryAttempts : 2,
+            },
+        };
+
+        /// <summary>
+        /// Parse a comma-separated list of ulong ids — the shared storage format
+        /// used by both <c>AdminRoleIds</c> and <c>ListenChannelIds</c>. Blank and
+        /// unparseable entries are skipped.
+        /// </summary>
+        public static IReadOnlyList<ulong> ParseIds(string? csv)
+        {
+            if (string.IsNullOrWhiteSpace(csv)) return Array.Empty<ulong>();
+            return csv
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(p => ulong.TryParse(p, out var id) ? id : 0UL)
+                .Where(id => id != 0)
+                .ToList();
+        }
+    }
+
+    public sealed class ChannelSettings
+    {
+        public ulong Log { get; init; }
+        public ulong EvilLog { get; init; }
+        public ulong VerifyLog { get; init; }
+        public ulong Rules { get; init; }
+        public ulong GiveawayScoreboard { get; init; }
+
+        /// <summary>Channels Airy listens and responds in.</summary>
+        public IReadOnlyList<ulong> Listen { get; init; } = Array.Empty<ulong>();
+    }
+
+    public sealed class RoleSettings
+    {
+        public ulong Verified { get; init; }
+        public ulong Unverified { get; init; }
+
+        /// <summary>Roles allowed to run admin/moderation commands.</summary>
+        public IReadOnlyList<ulong> Admin { get; init; } = Array.Empty<ulong>();
+    }
+
+    public sealed class CategorySettings
+    {
+        /// <summary>Category under which private contact channels are created.</summary>
+        public ulong Contact { get; init; }
+    }
+
+    public sealed class AiSettings
+    {
+        public string Model { get; init; } = "gpt-4.1-mini";
+        public string Prompt { get; init; } = string.Empty;
+        public int MaxTokens { get; init; } = 1000;
+        public int RetryAttempts { get; init; } = 2;
+    }
+}

--- a/AiryBotCode.Application/Settings/ISettingsProvider.cs
+++ b/AiryBotCode.Application/Settings/ISettingsProvider.cs
@@ -1,0 +1,26 @@
+namespace AiryBotCode.Application.Settings
+{
+    /// <summary>
+    /// Holds the preloaded <see cref="AirySettings"/> tree for the whole app.
+    /// Registered as a singleton; loaded once at startup before the bot handles
+    /// any events, so handlers never block on a DB read mid-interaction.
+    /// </summary>
+    public interface ISettingsProvider
+    {
+        /// <summary>
+        /// The current in-memory settings. Lazy-loads on first access if
+        /// <see cref="LoadAsync"/> was not called at startup (keeps handlers safe
+        /// even on bots that haven't wired the explicit preload yet).
+        /// </summary>
+        AirySettings Current { get; }
+
+        /// <summary>
+        /// Load (or reload) settings from the persisted <c>BotSetting</c>. Call
+        /// once at startup, after seeding and before the bot begins handling events.
+        /// </summary>
+        Task<AirySettings> LoadAsync();
+
+        /// <summary>Re-read settings (e.g. after a UI save) so changes go live.</summary>
+        Task<AirySettings> RefreshAsync();
+    }
+}

--- a/AiryBotCode.Application/Settings/SettingsProvider.cs
+++ b/AiryBotCode.Application/Settings/SettingsProvider.cs
@@ -1,0 +1,73 @@
+using AiryBotCode.Application.Interfaces;
+using AiryBotCode.Application.Interfaces.Repository;
+using AiryBotCode.Domain.database;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AiryBotCode.Application.Settings
+{
+    /// <summary>
+    /// Default <see cref="ISettingsProvider"/>: preloads <see cref="AirySettings"/>
+    /// once and hands the same tree to every handler. Reads the persisted
+    /// <see cref="BotSetting"/> (seeded from config) and projects it via
+    /// <see cref="AirySettings.FromBotSetting"/>; falls back to config-built
+    /// settings if the database row isn't there yet.
+    /// </summary>
+    public class SettingsProvider : ISettingsProvider
+    {
+        private readonly IServiceProvider _services;
+        private readonly IConfigurationReader _config;
+        private readonly object _lock = new();
+        private AirySettings? _current;
+
+        public SettingsProvider(IServiceProvider services, IConfigurationReader config)
+        {
+            _services = services;
+            _config = config;
+        }
+
+        public AirySettings Current
+        {
+            get
+            {
+                var snapshot = _current;
+                if (snapshot != null) return snapshot;
+                // Nobody preloaded at startup — load now (blocking) so handlers stay safe.
+                return LoadAsync().GetAwaiter().GetResult();
+            }
+        }
+
+        public async Task<AirySettings> LoadAsync()
+        {
+            var (setting, origin) = await ReadSettingAsync();
+            var built = AirySettings.FromBotSetting(setting);
+            lock (_lock) { _current = built; }
+
+            Console.WriteLine(
+                $"[SETTINGS] Loaded for bot '{setting.BotName}' (source: {origin}). " +
+                $"Owner={built.Owner}, Listen={built.Channels.Listen.Count} channel(s), " +
+                $"Admin={built.Roles.Admin.Count} role(s).");
+
+            return built;
+        }
+
+        public Task<AirySettings> RefreshAsync() => LoadAsync();
+
+        private async Task<(BotSetting setting, string origin)> ReadSettingAsync()
+        {
+            try
+            {
+                using var scope = _services.CreateScope();
+                var repo = scope.ServiceProvider.GetRequiredService<IBotSettingRepository>();
+                var setting = await repo.GetBotSettingAsync(_config.GetBotId());
+                if (setting != null) return (setting, "database");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[SETTINGS] DB read failed, falling back to config: {ex.Message}");
+            }
+
+            // No persisted row yet — build straight from configuration.
+            return (_config.GetBotSettings(), "config");
+        }
+    }
+}

--- a/AiryBotCode.Domain/database/BotSetting.cs
+++ b/AiryBotCode.Domain/database/BotSetting.cs
@@ -14,5 +14,25 @@ namespace AiryBotCode.Domain.database
         public ulong LogChannelId { get; set; }
         public ulong EvilLogChannelId { get; set; }
         public ulong BotId { get; set; }
+
+        // --- Values previously hardcoded in interaction handlers ---
+        // These back the grouped AirySettings tree so handlers read them from
+        // one place instead of inline literals. All optional / default-safe.
+
+        /// <summary>Owner / super-admin user id (owner-only checks).</summary>
+        public ulong OwnerId { get; set; }
+
+        /// <summary>Comma-separated channel ids Airy listens/responds in.</summary>
+        public string? ListenChannelIds { get; set; }
+
+        public ulong VerifiedRoleId { get; set; }
+        public ulong UnverifiedRoleId { get; set; }
+        public ulong VerifyLogChannelId { get; set; }
+        public ulong RulesChannelId { get; set; }
+        public ulong GiveawayScoreboardChannelId { get; set; }
+        public ulong ContactCategoryId { get; set; }
+
+        public int MaxTokens { get; set; }
+        public int RetryAttempts { get; set; }
     }
 }

--- a/AiryBotCode.Infrastructure/Database/Persistence/Config/BotSettingConfiguration.cs
+++ b/AiryBotCode.Infrastructure/Database/Persistence/Config/BotSettingConfiguration.cs
@@ -34,7 +34,18 @@ namespace AiryBotCode.Infrastructure.Database.Persistence.Config
 
             builder.Property(bs => bs.EvilLogChannelId);
 
-
+            // Values surfaced through the AirySettings registry (all optional).
+            builder.Property(bs => bs.OwnerId);
+            builder.Property(bs => bs.ListenChannelIds)
+                .IsRequired(false); // CSV of channel ids, like AdminRoleIds
+            builder.Property(bs => bs.VerifiedRoleId);
+            builder.Property(bs => bs.UnverifiedRoleId);
+            builder.Property(bs => bs.VerifyLogChannelId);
+            builder.Property(bs => bs.RulesChannelId);
+            builder.Property(bs => bs.GiveawayScoreboardChannelId);
+            builder.Property(bs => bs.ContactCategoryId);
+            builder.Property(bs => bs.MaxTokens);
+            builder.Property(bs => bs.RetryAttempts);
         }
     }
 }

--- a/Bots/AiryBotCode.AiryDevBot/Bots/AiryDevBot.cs
+++ b/Bots/AiryBotCode.AiryDevBot/Bots/AiryDevBot.cs
@@ -1,4 +1,5 @@
 ﻿using AiryBotCode.Application.Interfaces;
+using AiryBotCode.Application.Settings;
 using AiryBotCode.Infrastructure.Activitys;
 using Discord;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,6 +42,10 @@ namespace AiryBotCode.Bot.Bots
 
         public override async Task StartAsync(IServiceProvider services)
         {
+            // Preload settings before any events are hooked, so interaction
+            // handlers read the settings registry instead of hardcoded values.
+            await services.GetRequiredService<ISettingsProvider>().LoadAsync();
+
             var discordToken = _configuration.GetBotToken();
             await _client.LoginAsync(TokenType.Bot, discordToken);
             await _client.StartAsync();

--- a/Bots/AiryBotCode.AiryDevBot/appsettings.example.json
+++ b/Bots/AiryBotCode.AiryDevBot/appsettings.example.json
@@ -8,7 +8,10 @@
   },
   "OpenAI": {
     "ApiKey": "YOUR_OPENAI_API_KEY",
-    "Prompt": "You are Airy, a helpful AI assistant in a multi-user Discord channel. Pay attention to the 'name' attribute on each user message to understand who is speaking. Address users by their name when it feels natural. Use Discord markdown format for your responses."
+    "Model": "gpt-4.1-mini",
+    "Prompt": "You are Airy, a helpful AI assistant in a multi-user Discord channel. Pay attention to the 'name' attribute on each user message to understand who is speaking. Address users by their name when it feels natural. Use Discord markdown format for your responses.",
+    "MaxTokens": 1000,
+    "RetryAttempts": 2
   },
   "Bots": {
     "Name": "DevAiryBot",
@@ -18,6 +21,15 @@
     "EvilId": "YOUR_EVIL_ID",
     "LogChannelId": "YOUR_LOG_CHANNEL_ID",
     "EvilLogChannelId": "YOUR_EVIL_LOG_CHANNEL_ID",
-    "BotId": "YOUR_BOT_ID"
+    "BotId": "YOUR_BOT_ID",
+
+    "OwnerId": "YOUR_OWNER_USER_ID",
+    "ListenChannelIds": [ "CHANNEL_ID_1", "CHANNEL_ID_2" ],
+    "VerifiedRoleId": "YOUR_VERIFIED_ROLE_ID",
+    "UnverifiedRoleId": "YOUR_UNVERIFIED_ROLE_ID",
+    "VerifyLogChannelId": "YOUR_VERIFY_LOG_CHANNEL_ID",
+    "RulesChannelId": "YOUR_RULES_CHANNEL_ID",
+    "GiveawayScoreboardChannelId": "YOUR_GIVEAWAY_SCOREBOARD_CHANNEL_ID",
+    "ContactCategoryId": "YOUR_CONTACT_CATEGORY_ID"
   }
 }


### PR DESCRIPTION
Introduce AiryBotCode.Application/Settings as the single, grouped source of
truth for runtime values (Owner, Channels, Roles, Categories, Ai). Settings are
projected from the persisted BotSetting and preloaded once at startup via
ISettingsProvider, before the bot handles events.

- Extend BotSetting (+ EF config, ConfigurationReader, example config) with the
  values previously hardcoded in handlers; all optional/default-safe.
- Migrate high-value handlers off inline literals:
  - GiveawayCommand: owner-id checks + scoreboard channel
  - TalkToAiry: listen channels + AI model/max_tokens
  - VerifyUserAgeCommand: verified/unverified roles + verify log channel
  - UserService: drop lazy ADMINROLEID env var, use Roles.Admin
- OpenAIClient: max_tokens is now a constructor parameter.

Stepping stone toward UI-driven, config-file-free settings (RefreshAsync).

https://claude.ai/code/session_01NRAjcRymPxC1GhGSNDomQE