### PR TITLE
SpamCatcher: auto-timeout cross-channel spam from a monitored role

### DIFF
--- a/AiryBotCode.Application/Features/SpamCatcher/SpamCatcherCommand.cs
+++ b/AiryBotCode.Application/Features/SpamCatcher/SpamCatcherCommand.cs
@@ -1,0 +1,124 @@
+using AiryBotCode.Application.Features.Logging;
+using AiryBotCode.Application.Services.User;
+using AiryBotCode.Domain.Configuration.Attributes;
+using AiryBotCode.Domain.Entities;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AiryBotCode.Application.Features.SpamCatcher
+{
+    /// <summary>
+    /// Message-driven anti-spam. A member who holds the configured role and posts a
+    /// burst of messages across several channels in a short window is automatically
+    /// timed out, the burst is deleted, and the action is logged like any other
+    /// moderation log.
+    ///
+    /// This is NOT a slash command — it has no <see cref="GetCommand"/>. It exists as
+    /// a <see cref="EvilCommand"/> only so its tunables flow through the standard
+    /// [ConfigurableCommand] settings/seed/hot-reload pipeline, and so it can be
+    /// enabled per-bot from the control panel.
+    /// </summary>
+    [ConfigurableCommand("SpamCatcherCommand")]
+    public class SpamCatcherCommand : EvilCommand
+    {
+        // --- Settings Declaration for Seeder ---
+        [ReloadableSetting("Role that is watched for cross-channel spam. Empty (0) = catcher OFF. Only members WITH this role are monitored, each one independently.", Category = "SpamCatcher")]
+        public ulong MonitoredRoleId { get; set; } = 0;            // base: empty (off)
+
+        [ReloadableSetting("How many messages within the window count as spam.", Category = "SpamCatcher", UiHint = "number")]
+        public int MessageThreshold { get; set; } = 3;             // base: 3
+
+        [ReloadableSetting("How many DISTINCT channels the burst must span.", Category = "SpamCatcher", UiHint = "number")]
+        public int DistinctChannels { get; set; } = 2;             // base: 2
+
+        [ReloadableSetting("Sliding time window, in seconds.", Category = "SpamCatcher", UiHint = "number")]
+        public int WindowSeconds { get; set; } = 6;                // base: 6
+
+        [ReloadableSetting("Timeout applied to a caught spammer, in minutes.", Category = "SpamCatcher", UiHint = "number")]
+        public int TimeoutMinutes { get; set; } = 1440;            // base: 24h
+
+        [ReloadableSetting("Delete the offending messages when spam is caught.", Category = "SpamCatcher")]
+        public bool DeleteMessages { get; set; } = true;           // base: true
+        // --- End of Settings Declaration ---
+
+        private readonly UserService _userService;
+        private readonly UserlogsCommand _userlogs;
+        private readonly SpamTracker _tracker;
+
+        public SpamCatcherCommand(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            Name = "spamcatcher";
+            _userService = serviceProvider.GetRequiredService<UserService>();
+            _userlogs = serviceProvider.GetRequiredService<UserlogsCommand>();
+            _tracker = serviceProvider.GetRequiredService<SpamTracker>();
+        }
+
+        // Message-driven only: never registered as a slash command.
+        public override SlashCommandBuilder GetCommand() =>
+            throw new NotSupportedException("SpamCatcherCommand is message-driven and has no slash command.");
+
+        public async Task HandleMessageAsync(SocketMessage message)
+        {
+            // Off until a role is configured.
+            if (MonitoredRoleId == 0) return;
+
+            // Guild text messages from real members only (bots are already filtered
+            // upstream, but guard anyway).
+            if (message.Author.IsBot) return;
+            if (message is not SocketUserMessage) return;
+            if (message.Channel is not SocketGuildChannel guildChannel) return;
+            if (message.Author is not SocketGuildUser member) return;
+
+            // Only members who hold the monitored role are watched.
+            if (!member.Roles.Any(r => r.Id == MonitoredRoleId)) return;
+
+            var offending = _tracker.Record(
+                guildChannel.Guild.Id, member.Id, message.Channel.Id, message.Id,
+                MessageThreshold, DistinctChannels, WindowSeconds);
+            if (offending == null) return;   // not spam (yet)
+
+            var distinct = offending.Select(o => o.ChannelId).Distinct().Count();
+            Console.WriteLine($"[SpamCatcher] {member.Username} ({member.Id}) tripped — {offending.Count} msgs across {distinct} channels in {WindowSeconds}s.");
+
+            // 1) Timeout the spammer.
+            try { await _userService.TimeOutUser(member, TimeoutMinutes); }
+            catch (Exception ex) { Console.WriteLine($"[SpamCatcher] timeout failed: {ex.Message}"); }
+
+            // 2) Delete the offending burst.
+            int deleted = 0;
+            if (DeleteMessages)
+            {
+                foreach (var (chId, msgId) in offending)
+                {
+                    try
+                    {
+                        if (_client.GetChannel(chId) is IMessageChannel ch)
+                        {
+                            await ch.DeleteMessageAsync(msgId);
+                            deleted++;
+                        }
+                    }
+                    catch (Exception ex) { Console.WriteLine($"[SpamCatcher] delete failed for {msgId}: {ex.Message}"); }
+                }
+            }
+
+            // 3) Log it to the log channel, like the other moderation logs (logged by
+            //    the bot itself, type Timeout).
+            try
+            {
+                var until = DateTimeOffset.UtcNow.AddMinutes(TimeoutMinutes);
+                var info = new LogInfo
+                {
+                    Type = LogType.Timeout,
+                    Target = member,
+                    Reason = $"Automatic spam detection: {offending.Count} messages across {distinct} channels within {WindowSeconds}s.",
+                    Action = $"Timed out for {TimeoutMinutes} minute(s); {deleted} message(s) deleted.",
+                    Consequences = $"Muted until `{until:f}` UTC."
+                };
+                await _userlogs.SendUserLog(_client.CurrentUser, info);
+            }
+            catch (Exception ex) { Console.WriteLine($"[SpamCatcher] log failed: {ex.Message}"); }
+        }
+    }
+}

--- a/AiryBotCode.Application/Features/SpamCatcher/SpamTracker.cs
+++ b/AiryBotCode.Application/Features/SpamCatcher/SpamTracker.cs
@@ -1,0 +1,64 @@
+namespace AiryBotCode.Application.Features.SpamCatcher
+{
+    /// <summary>
+    /// In-memory sliding-window tracker for cross-channel spam, keyed PER USER
+    /// (per guild). Every monitored member is tracked independently — messages from
+    /// different role-holders are never pooled together.
+    ///
+    /// Registered as a singleton so the window survives across the request-scoped
+    /// message handlers. Thread-safe: the Discord gateway dispatches message events
+    /// concurrently (handlers are offloaded with Task.Run).
+    /// </summary>
+    public sealed class SpamTracker
+    {
+        private readonly record struct Entry(ulong ChannelId, ulong MessageId, DateTimeOffset At);
+
+        private readonly Dictionary<(ulong Guild, ulong User), List<Entry>> _events = new();
+        private readonly Dictionary<(ulong Guild, ulong User), DateTimeOffset> _cooldownUntil = new();
+        private readonly object _lock = new();
+
+        /// <summary>
+        /// Record one message from a monitored user. Returns the burst of offending
+        /// messages (channel + message ids) when this message tips the user over the
+        /// threshold — enough messages spread across enough distinct channels inside
+        /// the window — otherwise null.
+        ///
+        /// On a trigger the user's window is cleared and a short cooldown is set so a
+        /// single burst fires exactly once while the timeout/delete is applied.
+        /// </summary>
+        public IReadOnlyList<(ulong ChannelId, ulong MessageId)>? Record(
+            ulong guildId, ulong userId, ulong channelId, ulong messageId,
+            int messageThreshold, int distinctChannels, int windowSeconds,
+            DateTimeOffset? at = null)
+        {
+            lock (_lock)
+            {
+                var now = at ?? DateTimeOffset.UtcNow;
+                var key = (guildId, userId);
+
+                // Just caught this user — ignore the tail of the same burst.
+                if (_cooldownUntil.TryGetValue(key, out var until) && until > now)
+                    return null;
+
+                if (!_events.TryGetValue(key, out var list))
+                    _events[key] = list = new List<Entry>();
+
+                // Drop anything that has aged out of the window, then add this message.
+                var cutoff = now.AddSeconds(-windowSeconds);
+                list.RemoveAll(e => e.At < cutoff);
+                list.Add(new Entry(channelId, messageId, now));
+
+                var distinct = list.Select(e => e.ChannelId).Distinct().Count();
+                if (list.Count >= messageThreshold && distinct >= distinctChannels)
+                {
+                    var offending = list.Select(e => (e.ChannelId, e.MessageId)).ToList();
+                    list.Clear();
+                    _cooldownUntil[key] = now.AddSeconds(Math.Max(windowSeconds, 10));
+                    return offending;
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/AiryBotCode.Application/RegisterApplication.cs
+++ b/AiryBotCode.Application/RegisterApplication.cs
@@ -28,6 +28,9 @@ namespace AiryBotCode.Application
             services.AddScoped<VerifyUserAgeCommand>();
             services.AddScoped<ContactUserCommand>();
             services.AddScoped<GiveawayCommand>();
+            services.AddScoped<Features.SpamCatcher.SpamCatcherCommand>();
+            // Per-user spam sliding-window state — shared across message handlers.
+            services.AddSingleton<Features.SpamCatcher.SpamTracker>();
             // SERVICES
             services.AddScoped<UserService>();
             services.AddScoped<LogService>();

--- a/AiryBotCode.Application/Services/User/UserService.cs
+++ b/AiryBotCode.Application/Services/User/UserService.cs
@@ -74,6 +74,14 @@ namespace AiryBotCode.Application.Services.User
             var timeoutDuration = TimeSpan.FromMinutes(durationMinutes);
             await target.SetTimeOutAsync(timeoutDuration);
         }
+        // Overload for non-interaction callers (e.g. the spam catcher reacting to a
+        // message rather than a slash command).
+        public async Task TimeOutUser(SocketGuildUser target, int durationMinutes)
+        {
+            if (target == null) return;
+            await target.SetTimeOutAsync(TimeSpan.FromMinutes(durationMinutes));
+        }
+
         public async Task UntimeOut(SocketInteraction command, SocketGuildUser target)
         {
             if (target == null)

--- a/AiryBotCode.Infrastructure/Activitys/SpamCatcherAction.cs
+++ b/AiryBotCode.Infrastructure/Activitys/SpamCatcherAction.cs
@@ -1,0 +1,25 @@
+using AiryBotCode.Application.Features.SpamCatcher;
+using AiryBotCode.Infrastructure.Interfaces;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AiryBotCode.Infrastructure.Activitys
+{
+    /// <summary>
+    /// Adapter that feeds every received message into the spam catcher. Implements
+    /// only <see cref="IMessageAction"/>, so the reflection-based ActionCatalog picks
+    /// it up but the slash-command registrar ignores it.
+    /// </summary>
+    public class SpamCatcherAction : EvilAction, IMessageAction
+    {
+        public SpamCatcherAction(IServiceProvider serviceProvider)
+            : base(serviceProvider.GetRequiredService<SpamCatcherCommand>(), serviceProvider)
+        {
+        }
+
+        public async Task HandleMessageReceivedAsync(SocketMessage message)
+        {
+            await ((SpamCatcherCommand)Command).HandleMessageAsync(message);
+        }
+    }
+}

--- a/AiryBotCode.Infrastructure/Registers/RegisterInfrastructure.cs
+++ b/AiryBotCode.Infrastructure/Registers/RegisterInfrastructure.cs
@@ -69,6 +69,7 @@ namespace AiryBotCode.Infrastructure.Registers
             services.AddScoped<VerifyUserAgeAction>();
             services.AddScoped<ContactUserAction>();
             services.AddScoped<GiveawayAction>();
+            services.AddScoped<SpamCatcherAction>();
             return services;
         }
     }

--- a/AiryBotCode.Tests/SpamTrackerTests.cs
+++ b/AiryBotCode.Tests/SpamTrackerTests.cs
@@ -1,0 +1,81 @@
+using AiryBotCode.Application.Features.SpamCatcher;
+using Xunit;
+
+namespace AiryBotCode.Tests
+{
+    public class SpamTrackerTests
+    {
+        private static readonly DateTimeOffset T0 = new(2026, 6, 16, 8, 0, 0, TimeSpan.Zero);
+
+        // Base config: 3 messages across 2 distinct channels within 6 seconds.
+        private const ulong G = 1, U = 100, C1 = 10, C2 = 20, C3 = 30;
+        private const int Threshold = 3, Distinct = 2, Window = 6;
+
+        private static IReadOnlyList<(ulong, ulong)>? Rec(
+            SpamTracker t, ulong channel, ulong message, DateTimeOffset at, ulong user = U) =>
+            t.Record(G, user, channel, message, Threshold, Distinct, Window, at);
+
+        [Fact]
+        public void Below_message_threshold_does_not_trigger()
+        {
+            var t = new SpamTracker();
+            Assert.Null(Rec(t, C1, 1, T0));
+            Assert.Null(Rec(t, C2, 2, T0.AddSeconds(1)));   // only 2 messages
+        }
+
+        [Fact]
+        public void Enough_messages_but_one_channel_does_not_trigger()
+        {
+            var t = new SpamTracker();
+            Assert.Null(Rec(t, C1, 1, T0));
+            Assert.Null(Rec(t, C1, 2, T0.AddSeconds(1)));
+            Assert.Null(Rec(t, C1, 3, T0.AddSeconds(2)));   // 3 msgs, only 1 distinct channel
+        }
+
+        [Fact]
+        public void Burst_across_channels_within_window_triggers_and_returns_burst()
+        {
+            var t = new SpamTracker();
+            Assert.Null(Rec(t, C1, 1, T0));
+            Assert.Null(Rec(t, C2, 2, T0.AddSeconds(2)));
+            var hit = Rec(t, C3, 3, T0.AddSeconds(4));       // 3 msgs / 3 channels / 4s
+
+            Assert.NotNull(hit);
+            Assert.Equal(3, hit!.Count);
+            Assert.Equal(new[] { (C1, 1UL), (C2, 2UL), (C3, 3UL) }, hit);
+        }
+
+        [Fact]
+        public void Messages_outside_the_window_are_dropped()
+        {
+            var t = new SpamTracker();
+            Assert.Null(Rec(t, C1, 1, T0));
+            Assert.Null(Rec(t, C2, 2, T0.AddSeconds(2)));
+            // 3rd lands after the first has aged out → window holds only msgs 2 & 3.
+            Assert.Null(Rec(t, C3, 3, T0.AddSeconds(7)));
+        }
+
+        [Fact]
+        public void Each_user_is_tracked_independently()
+        {
+            var t = new SpamTracker();
+            // Two different users each send across two channels — neither alone trips.
+            Assert.Null(Rec(t, C1, 1, T0, user: 100));
+            Assert.Null(Rec(t, C2, 2, T0.AddSeconds(1), user: 200));
+            Assert.Null(Rec(t, C2, 3, T0.AddSeconds(2), user: 100)); // user 100: 2 msgs
+            Assert.Null(Rec(t, C1, 4, T0.AddSeconds(3), user: 200)); // user 200: 2 msgs
+        }
+
+        [Fact]
+        public void Cooldown_prevents_immediate_retrigger_from_the_same_burst()
+        {
+            var t = new SpamTracker();
+            Assert.Null(Rec(t, C1, 1, T0));
+            Assert.Null(Rec(t, C2, 2, T0.AddSeconds(1)));
+            Assert.NotNull(Rec(t, C3, 3, T0.AddSeconds(2)));         // trips
+            // The tail of the same burst must not fire a second timeout.
+            Assert.Null(Rec(t, C1, 4, T0.AddSeconds(3)));
+            Assert.Null(Rec(t, C2, 5, T0.AddSeconds(4)));
+        }
+    }
+}


### PR DESCRIPTION
## What

A message-driven anti-spam feature. When a member who holds a configured role posts a **burst** — enough messages, across enough distinct channels, inside a short window — they're automatically **timed out**, the burst messages are **deleted**, and the action is **logged** to the log channel like any other moderation log (type `Timeout`, logged by the bot).

It's built into the existing **Command + Action + `[ConfigurableCommand]` settings** pattern, so it gets per-bot enablement, panel settings, and hot-reload for free.

## Settings (all reloadable from the control panel)

| Setting | Base | Meaning |
|---|---|---|
| `MonitoredRoleId` | empty (0) | **Off** until set. Only members *with* this role are watched. |
| `MessageThreshold` | 3 | messages within the window |
| `DistinctChannels` | 2 | how many different channels the burst must span |
| `WindowSeconds` | 6 | sliding window |
| `TimeoutMinutes` | 1440 | timeout length (24h) |
| `DeleteMessages` | true | delete the offending burst |

## Design notes

- **Per-user tracking** — `SpamTracker` keys the sliding window by `(guild, user)`, so each role-holder is watched independently; messages from different users are never pooled together. A short cooldown ensures one burst fires exactly once while the timeout/delete is applied.
- **Opt-in everywhere (safe by default):** empty role = off, and the action seeds **disabled per-bot** (new commands default to disabled). On `AiryDevBot` it's enabled from the panel; the hardcoded production `AiryBot` list is unchanged.
- Reuses `UserlogsCommand.SendUserLog` for the log embed, and adds a non-interaction `UserService.TimeOutUser(target, minutes)` overload.

## Files

- `Application/Features/SpamCatcher/SpamCatcherCommand.cs` — settings + detect/timeout/delete/log logic (not a slash command)
- `Application/Features/SpamCatcher/SpamTracker.cs` — singleton sliding-window state, time injectable for tests
- `Infrastructure/Activitys/SpamCatcherAction.cs` — `IMessageAction` adapter (picked up by `ActionCatalog`)
- `Application/Services/User/UserService.cs` — `TimeOutUser(target, minutes)` overload
- DI wiring in `RegisterApplication.cs` / `RegisterInfrastructure.cs`
- `AiryBotCode.Tests/SpamTrackerTests.cs` — threshold / distinct-channel / window-expiry / per-user isolation / cooldown

## Verification

⚠️ No .NET SDK was available in the build environment, so this was **not compiled or tested here** — please run `dotnet build` + `dotnet test` locally. Verified by review against the net8.0 / nullable settings and existing patterns (`GetCommand()` is only invoked for slash actions, which this is not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUowY7UbqsNKGDCcNBzZcr)_